### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@goanpeca](https://github.com/goanpeca/)
 * [@haesleinhuepf](https://github.com/haesleinhuepf/)
 * [@jaimergp](https://github.com/jaimergp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - jaimergp
     - haesleinhuepf
     - zoccoler


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #11